### PR TITLE
Release 1.38.0 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,9 @@ For complete details please see: Using a declarative or scripted pipeline in the
 
 #### Enhancement
 
-- Get and update DevOps Change Request details
-    - Get and update change request details associated with a Jenkins pipeline by running the snDevOpsGetChangeNumber and snDevOpsUpdateChangeInfo scripts respectively in the Jenkins pipeline.
+- Logging change status while pipeline is pending decision to resume execution
+    - Change information such as, Change Number, State, Assignment Group, Approvers, Planned Start/End date is displayed in the console logs of Jenkins and GitHub Actions, while the pipeline/workflow is pending for change approval. The ServiceNow DevOps application is polled at regular intervals and if there is any difference in the change information, it is logged directly in the console logs, thereby minimizing the hops to ServiceNow instance.
 
-#### Defects fixed
-
-- Jenkins Discover fails with large number of pipelines/jobs.
 
 **NOTE**: The ServiceNow DevOps plugin now requires 2.289.1+ as a minimum version
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>servicenow-devops</artifactId>
-    <version>1.37.0</version>
+    <version>1.38.0</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.289.1</jenkins.version>

--- a/src/main/java/io/jenkins/plugins/model/DevOpsChangePollingModel.java
+++ b/src/main/java/io/jenkins/plugins/model/DevOpsChangePollingModel.java
@@ -1,0 +1,246 @@
+package io.jenkins.plugins.model;
+
+import hudson.AbortException;
+import hudson.EnvVars;
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import io.jenkins.plugins.DevOpsRootAction;
+import io.jenkins.plugins.DevOpsRunStatusAction;
+import io.jenkins.plugins.config.DevOpsConfiguration;
+import io.jenkins.plugins.pipeline.steps.executions.DevOpsPipelineChangeStepExecution;
+import io.jenkins.plugins.utils.CommUtils;
+import io.jenkins.plugins.utils.DevOpsConstants;
+import io.jenkins.plugins.utils.GenericUtils;
+import net.sf.json.JSONObject;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.logging.Level;
+
+import static io.jenkins.plugins.DevOpsRunListener.DevOpsStageListener.getCurrentStageId;
+
+public class DevOpsChangePollingModel {
+    public DevOpsPipelineNode getStageNodeById(Run<?, ?> run, String stageId) {
+        DevOpsModel model = new DevOpsModel();
+        return model.getStageNodeById(run, stageId);
+    }
+    public long getChangeStartTime(Run<?, ?> run, String stageId){
+        DevOpsPipelineNode currentNode = getStageNodeById(run, stageId);
+        if (null != currentNode)
+            return currentNode.getChangeStartTime();
+        return 0;
+    }
+
+    public void setChangeStartTime(Run<?, ?> run, String stageId, long startTime){
+        DevOpsPipelineNode currentNode = getStageNodeById(run, stageId);
+        if (null != currentNode)
+            currentNode.setChangeStartTime(startTime);
+    }
+    public void launchChangePollingThread(TaskListener listener, Run<?, ?> run, Job<?, ?> controlledJob,
+                                          DevOpsPipelineChangeStepExecution stepExecution) {
+
+        DevOpsPipelineGraph graph = run.getAction(DevOpsRunStatusAction.class).getPipelineGraph();
+        String stageId = getCurrentStageId(stepExecution.getContext(), graph);
+        long startTime = System.currentTimeMillis();
+        if(this.getChangeStartTime(run,stageId) > 0)
+            startTime = this.getChangeStartTime(run,stageId);
+        else
+            this.setChangeStartTime(run,stageId, startTime);
+
+        long pollingIntervalFinal = stepExecution.getStep().getPollingInterval() > 0 ? stepExecution.getStep().getPollingInterval() * 1000l : -1;
+        long changeFailureTimeoutFinal = stepExecution.getStep().getChangeCreationTimeOut() * 1000l;
+        long changeStepTimeoutFinal = stepExecution.getStep().getChangeStepTimeOut() * 1000l ;
+
+        if(pollingIntervalFinal <=0 && changeFailureTimeoutFinal <= 0 && changeStepTimeoutFinal <= 0)
+            return;
+
+        final long stageStartTime = startTime;
+        Runnable pollingThread = () ->
+        {
+            Thread.currentThread().setName("DevopsChangePollingThread");
+            final String CHG_STEP = "changeStep"; // Priority: 1
+            final String CHG_CREATION = "changeCreation"; // Priority: 2
+            final String POLLING = "polling"; // Priority: 3
+            class Interval {
+                long intervalTime;
+                String type;
+                int priority;
+                public Interval(long intervalTime, int priority, String type){
+                    this.intervalTime = intervalTime;
+                    this.type = type;
+                    this.priority = priority;
+                }
+            }
+            Comparator<Interval> comparator = (Interval interval1, Interval interval2) -> {
+                if (interval1.intervalTime > interval2.intervalTime)
+                    return 1;
+                else if (interval1.intervalTime == interval2.intervalTime){
+                    if(interval1.priority > interval2.priority)
+                        return 1;
+                    else if (interval1.priority == interval2.priority)
+                        return 0;
+                    else
+                        return -1;
+                }
+                else return -1;
+            };
+            try {
+                long sleepTime = 0;
+                long nextPollingTime = pollingIntervalFinal;
+                boolean isChangeCreationChecked = false;
+                DevOpsChangeRequestDetails previousChangeDetails = new DevOpsChangeRequestDetails();
+                PriorityQueue<Interval> sleepIntervals = new PriorityQueue<>(3, comparator);
+                while(!Thread.currentThread().isInterrupted()) {
+                    long nextPollingTimeTemp = -1;
+                    if(pollingIntervalFinal >= 0)
+                        sleepIntervals.add(new Interval(nextPollingTime, 3, POLLING));
+
+                    long duration = System.currentTimeMillis() - stageStartTime;
+                    if(!isChangeCreationChecked && changeFailureTimeoutFinal > 0)
+                        if(changeFailureTimeoutFinal <= duration) {
+                            sleepIntervals.add(new Interval(0, 2, CHG_CREATION));
+                        }else if(changeFailureTimeoutFinal <= duration + nextPollingTime){
+                            sleepIntervals.add(new Interval(changeFailureTimeoutFinal - duration, 2, CHG_CREATION));
+                            nextPollingTimeTemp = nextPollingTime - (changeFailureTimeoutFinal - duration);
+                        }else
+                            sleepIntervals.add(new Interval(changeFailureTimeoutFinal - duration, 2, CHG_CREATION));
+
+                    if(changeStepTimeoutFinal > 0)
+                        if(changeStepTimeoutFinal <= duration) {
+                            sleepIntervals.add(new Interval(0, 1, CHG_STEP));
+                        }else if(changeStepTimeoutFinal <= duration + nextPollingTime){
+                            sleepIntervals.add(new Interval(changeStepTimeoutFinal - duration, 1, CHG_STEP));
+                            if(nextPollingTimeTemp == -1 || changeFailureTimeoutFinal > changeStepTimeoutFinal)
+                                nextPollingTimeTemp = nextPollingTime - (changeStepTimeoutFinal - duration);
+                        }else
+                            sleepIntervals.add(new Interval(changeStepTimeoutFinal - duration, 1, CHG_STEP));
+
+                    if(nextPollingTimeTemp != -1) nextPollingTime = nextPollingTimeTemp;
+                    if(sleepIntervals.isEmpty()) break;
+                    Interval nextInterval = sleepIntervals.poll();
+                    sleepTime  = nextInterval.intervalTime;
+                    if (sleepTime > 0) Thread.sleep(sleepTime);
+
+                    JSONObject response = this.getChangeStatusInfo(run, controlledJob, stepExecution);
+                    boolean changeFound = Boolean.parseBoolean(GenericUtils.parseResponseResult(response, DevOpsConstants.CHANGE_FOUND.toString()));
+                    switch (nextInterval.type){
+                        case CHG_CREATION:
+                            isChangeCreationChecked = true;
+                            if(!changeFound) this.checkAndLogChangeCreationFailure(stepExecution, listener);
+                            break;
+                        case CHG_STEP:
+                            this.checkAndLogChangeStepTimeout(stepExecution, listener);
+                            break;
+                        default:
+                            previousChangeDetails = this.logPollingMessages(listener, response, previousChangeDetails);
+                            nextPollingTime = pollingIntervalFinal;
+                    }
+                    sleepIntervals.clear();
+                }
+            } catch (InterruptedException e) {
+                printDebug("launchChangePollingThread", new String[]{"message"},
+                        new String[]{"[ServiceNow DevOps] Polling is stopped"}, Level.INFO);
+            } catch (Exception e) {
+                printDebug("launchChangePollingThread", new String[]{"exception"},
+                        new String[]{e.getMessage()}, Level.WARNING);
+            }
+        };
+        Thread pollingThreadImpl = new Thread(pollingThread);
+        stepExecution.setPollingThread(pollingThreadImpl);
+        pollingThreadImpl.start();
+    }
+
+    public void checkAndLogChangeStepTimeout(DevOpsPipelineChangeStepExecution stepExecution, TaskListener listener) throws IOException, InterruptedException {
+        boolean abort = stepExecution.getStep().isAbortOnChangeStepTimeOut();
+        listener.getLogger().println("[ServiceNow DevOps] Change Step timeout occurred.");
+        this.resumeOrAbortThePipeline(stepExecution, listener, abort, "Pipeline aborted due to change step timeout");
+    }
+    public void checkAndLogChangeCreationFailure (DevOpsPipelineChangeStepExecution stepExecution, TaskListener listener) throws IOException, InterruptedException {
+        boolean abort = stepExecution.getStep().isAbortOnChangeCreationFailure();
+        listener.getLogger().println("[ServiceNow DevOps] Change Creation failure timeout occurred.");
+        this.resumeOrAbortThePipeline(stepExecution, listener, abort, "Pipeline aborted due to change creation timeout");
+    }
+
+    public void resumeOrAbortThePipeline (DevOpsPipelineChangeStepExecution stepExecution, TaskListener listener, boolean abort, String failureMessage) throws IOException, InterruptedException {
+        DevOpsRootAction.deregisterPipelineWebhook(stepExecution);
+        if(abort){
+            stepExecution.getContext().get(Run.class).setResult(Result.FAILURE);
+            stepExecution.getContext().onFailure(new AbortException("[ServiceNow DevOps] " + failureMessage));
+            listener.getLogger().println("[ServiceNow DevOps] Aborting the pipeline");
+        }
+        else{
+            stepExecution.getContext().onSuccess("[ServiceNow DevOps] Resuming the pipeline");
+            listener.getLogger().println("[ServiceNow DevOps] Resuming the pipeline");
+        }
+        stepExecution.stopPollingThread();
+    }
+    public DevOpsChangeRequestDetails logPollingMessages (TaskListener listener, JSONObject response, DevOpsChangeRequestDetails previousChangeDetails){
+        boolean changeFound = Boolean.parseBoolean(GenericUtils.parseResponseResult(response, DevOpsConstants.CHANGE_FOUND.toString()));
+        if(changeFound){
+            String changeState = GenericUtils.parseResponseResult(response, DevOpsConstants.CHANGE_STATE_DISPLAY_VALUE.toString());
+            String changeAssignmentGroup = GenericUtils.parseResponseResult(response, DevOpsConstants.CHANGE_ASSIGNMENT_GROUP.toString());
+            String changeApprovers = GenericUtils.parseResponseResult(response, DevOpsConstants.CHANGE_APPROVERS.toString());
+            String changeStartDate = GenericUtils.parseResponseResult(response, DevOpsConstants.CHANGE_START_DATE.toString());
+            String changeEndDate = GenericUtils.parseResponseResult(response, DevOpsConstants.CHANGE_END_DATE.toString());
+            DevOpsChangeRequestDetails currentChangeDetails = new DevOpsChangeRequestDetails(changeState, changeAssignmentGroup, changeApprovers, changeStartDate, changeEndDate);
+            if(!previousChangeDetails.equals(currentChangeDetails)){
+                listener.getLogger().println();
+                listener.getLogger().println("[ServiceNow DevOps] Change State: " + changeState);
+                if(changeApprovers != null){
+                    listener.getLogger().println("[ServiceNow DevOps] Change AssignmentGroup: " + changeAssignmentGroup +
+                            ", Change Approvers: " + changeApprovers);
+                }if(GenericUtils.isNotEmpty(changeStartDate) && GenericUtils.isNotEmpty(changeEndDate)){
+                    listener.getLogger().println("[ServiceNow DevOps] Planned Start Date: " + changeStartDate + " UTC" +
+                            ", Planned End Date: " + changeEndDate + " UTC");
+                }
+                return currentChangeDetails;
+            }
+        }
+        return previousChangeDetails;
+    }
+
+    public JSONObject getChangeStatusInfo(Run<?, ?> run, Job<?, ?> controlledJob,
+                                          DevOpsPipelineChangeStepExecution stepExecution) throws IOException, InterruptedException {
+
+        JSONObject response = null;
+
+        if (run != null && controlledJob != null) {
+            JSONObject queryParams = new JSONObject();
+            String jobName = controlledJob.getName();
+            DevOpsPipelineGraph graph = run.getAction(DevOpsRunStatusAction.class).getPipelineGraph();
+
+            if (jobName != null) {
+                String stageId = getCurrentStageId(stepExecution.getContext(), graph);
+                DevOpsPipelineNode stageNode = getStageNodeById(run, stageId);
+                String stageName =  stageNode.getName();
+                String buildNumber = String.valueOf(run.getNumber());
+
+                EnvVars vars = stepExecution.getContext().get(EnvVars.class);
+                String branchName = vars.get(DevOpsConstants.PIPELINE_BRANCH_NAME.toString());
+                String pipelineName = vars.get(DevOpsConstants.PIPELINE_JOB_NAME.toString());
+
+                DevOpsConfiguration devopsConfig = GenericUtils.getDevOpsConfiguration();
+
+                queryParams.put(DevOpsConstants.TOOL_ID_ATTR.toString(), devopsConfig.getToolId());
+                queryParams.put(DevOpsConstants.TOOL_TYPE_ATTR.toString(), DevOpsConstants.TOOL_TYPE.toString());
+                queryParams.put(DevOpsConstants.ARTIFACT_PIPELINE_NAME.toString(), pipelineName);
+                queryParams.put(DevOpsConstants.ARTIFACT_STAGE_NAME.toString(), stageName);
+                queryParams.put(DevOpsConstants.CONFIG_BUILD_NUMBER.toString(), buildNumber);
+                queryParams.put(DevOpsConstants.SCM_BRANCH_NAME.toString(), branchName);
+
+                response = CommUtils.call(DevOpsConstants.REST_GET_METHOD.toString(), devopsConfig.getChangeInfoUrl(), queryParams,
+                        null, devopsConfig.getUser(), devopsConfig.getPwd(), null, null);
+
+            }
+        }
+        return response;
+    }
+    private void printDebug(String methodName, String[] variables, String[] values, Level logLevel) {
+        GenericUtils
+                .printDebug(DevOpsModel.class.getName(), methodName, variables, values,
+                        logLevel);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/model/DevOpsChangeRequestDetails.java
+++ b/src/main/java/io/jenkins/plugins/model/DevOpsChangeRequestDetails.java
@@ -1,0 +1,72 @@
+package io.jenkins.plugins.model;
+
+import java.util.Objects;
+
+public class DevOpsChangeRequestDetails {
+    String changeState;
+    String changeAssignmentGroup;
+    String changeApprovers;
+    String changeStartDate;
+    String changeEndDate;
+
+    public DevOpsChangeRequestDetails() {}
+    public DevOpsChangeRequestDetails(String changeState, String changeAssignmentGroup, String changeApprovers, String changeStartDate, String changeEndDate) {
+        this.changeState = changeState;
+        this.changeAssignmentGroup = changeAssignmentGroup;
+        this.changeApprovers = changeApprovers;
+        this.changeStartDate = changeStartDate;
+        this.changeEndDate = changeEndDate;
+    }
+    public String getChangeState() {
+        return changeState;
+    }
+
+    public void setChangeState(String changeState) {
+        this.changeState = changeState;
+    }
+
+    public String getChangeAssignmentGroup() {
+        return changeAssignmentGroup;
+    }
+
+    public void setChangeAssignmentGroup(String changeAssignmentGroup) {
+        this.changeAssignmentGroup = changeAssignmentGroup;
+    }
+
+    public String getChangeApprovers() {
+        return changeApprovers;
+    }
+
+    public void setChangeApprovers(String changeApprovers) {
+        this.changeApprovers = changeApprovers;
+    }
+
+    public String getChangeStartDate() {
+        return changeStartDate;
+    }
+
+    public void setChangeStartDate(String changeStartDate) {
+        this.changeStartDate = changeStartDate;
+    }
+
+    public String getChangeEndDate() {
+        return changeEndDate;
+    }
+
+    public void setChangeEndDate(String changeEndDate) {
+        this.changeEndDate = changeEndDate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DevOpsChangeRequestDetails)) return false;
+        DevOpsChangeRequestDetails that = (DevOpsChangeRequestDetails) o;
+        return Objects.equals(getChangeState(), that.getChangeState()) && Objects.equals(getChangeAssignmentGroup(), that.getChangeAssignmentGroup()) && Objects.equals(getChangeApprovers(), that.getChangeApprovers()) && Objects.equals(getChangeStartDate(), that.getChangeStartDate()) && Objects.equals(getChangeEndDate(), that.getChangeEndDate());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getChangeState(), getChangeAssignmentGroup(), getChangeApprovers(), getChangeStartDate(), getChangeEndDate());
+    }
+}

--- a/src/main/java/io/jenkins/plugins/model/DevOpsModel.java
+++ b/src/main/java/io/jenkins/plugins/model/DevOpsModel.java
@@ -8,17 +8,12 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
-import org.jenkinsci.plugins.workflow.actions.LabelAction;
-import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
-import org.jenkinsci.plugins.workflow.graph.FlowNode;
-import org.jenkinsci.plugins.workflow.graphanalysis.FlowScanningUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 import hudson.EnvVars;
@@ -618,8 +613,8 @@ public class DevOpsModel {
 	}
 
 	public String sendBuildAndToken(String token, String jenkinsUrl, String buildUrl,
-	                                String jobUrl, String jobName, String stageName,
-	                                DevOpsPipelineNode stageNode, Boolean isMultiBranch, String branchName, Boolean isChangeClose) {
+									String jobUrl, String jobName, String stageName,
+									DevOpsPipelineNode stageNode, Boolean isMultiBranch, String branchName, Boolean isChangeClose) {
 		printDebug("sendBuildAndToken", null, null, Level.FINE);
 		JSONObject params = new JSONObject();
 		JSONObject data = new JSONObject();
@@ -667,8 +662,8 @@ public class DevOpsModel {
 	}
 
 	public String sendIsUnderChgControl(String jobUrl, String jobName,
-	                                    String stageName, DevOpsPipelineNode stageNode, Boolean isMultiBranch,
-	                                    String branchName) {
+										String stageName, DevOpsPipelineNode stageNode, Boolean isMultiBranch,
+										String branchName) {
 		printDebug("sendIsUnderChgControl", null, null, Level.FINE);
 		JSONObject params = new JSONObject();
 		String result = null;
@@ -707,11 +702,11 @@ public class DevOpsModel {
 	}
 
 	public String sendJobAndCallbackUrl(String token, String jobUrl, String jobName,
-	                                    String stageName, DevOpsPipelineNode stageNode, String jenkinsUrl,
-	                                    String endpointUrl, String user, String pwd,
-	                                    String tool, JSONObject jobDetails,
+										String stageName, DevOpsPipelineNode stageNode, String jenkinsUrl,
+										String endpointUrl, String user, String pwd,
+										String tool, JSONObject jobDetails,
 										Boolean isMultiBranch, String branchName, String changeRequestDetails, PipelineChangeResponse changeResponse,
-											String applicationName, String snapshotName) {
+										String applicationName, String snapshotName) {
 		printDebug("sendJobAndCallbackUrl", null, null, Level.FINE);
 		JSONObject params = new JSONObject();
 		JSONObject data = new JSONObject();
@@ -734,6 +729,8 @@ public class DevOpsModel {
 				data.put(DevOpsConstants.JOB_NAME_ATTR.toString(),
 						jobName + DevOpsConstants.JOB_STAGE_SEPARATOR.toString() +
 								stageName);
+				data.put(DevOpsConstants.JOB_NAME_ATTR.toString(), jobName);
+				data.put(DevOpsConstants.STAGENAME_ATTR.toString(), stageName);
 				data.put(DevOpsConstants.JOB_URL_ATTR.toString(), replaceLast(jobUrl, "/",
 						DevOpsConstants.JOB_STAGE_SEPARATOR.toString() + stageName +
 								"/"));
@@ -763,7 +760,7 @@ public class DevOpsModel {
 					data.toString(), user, pwd, null, null);
 			result = GenericUtils
 					.parseResponseResult(response, DevOpsConstants.COMMON_RESPONSE_CHANGE_CTRL.toString());
-			
+
 			if(changeResponse != null) { // fill in message details if present
 				String message = GenericUtils.parseResponseResult(response, DevOpsConstants.COMMON_RESPONSE_MESSAGE.toString());
 				if(!GenericUtils.isEmpty(message)) {
@@ -793,7 +790,7 @@ public class DevOpsModel {
 	}
 
 	public String sendUpdateMapping(String jobUrl, String jobName, String stageName, DevOpsPipelineNode stageNode,
-	                                String stepSysId, Boolean isMultiBranch, String branchName) {
+									String stepSysId, Boolean isMultiBranch, String branchName) {
 		printDebug("sendUpdateMapping", null, null, Level.FINE);
 		JSONObject params = new JSONObject();
 		JSONObject data = new JSONObject();
@@ -872,8 +869,8 @@ public class DevOpsModel {
 	}
 
 	public String registerFreestyleAndNotify(Queue.Item item, Job<?, ?> job, String token,
-	                                         String jobId, String jobUrl, String jobName,
-	                                         String jenkinsUrl) {
+											 String jobId, String jobUrl, String jobName,
+											 String jenkinsUrl) {
 		printDebug("registerFreestyleAndNotify", null, null, Level.FINE);
 		String result = null;
 		try {
@@ -915,7 +912,7 @@ public class DevOpsModel {
 	}
 
 	public JSONObject getJobDetailsForFreestyle(Queue.Item item, Job<?, ?> controlledJob,
-	                                            String jenkinsUrl)
+												String jenkinsUrl)
 			throws InterruptedException {
 		printDebug("getJobDetailsForFreestyle", null, null, Level.FINE);
 		List<Cause> causes = item.getCauses();
@@ -923,7 +920,7 @@ public class DevOpsModel {
 	}
 
 	public JSONObject getJobDetailsForPipeline(Run<?, ?> run, Job<?, ?> controlledJob,
-	                                           String jenkinsUrl, DevOpsPipelineNode devOpsPipelineNode)
+											   String jenkinsUrl, DevOpsPipelineNode devOpsPipelineNode)
 			throws InterruptedException {
 		printDebug("getJobDetailsForPipeline", null, null, Level.FINE);
 		JSONObject json = new JSONObject();
@@ -951,7 +948,7 @@ public class DevOpsModel {
 	}
 
 	private JSONObject _getJobDetails(List<Cause> causes, Job<?, ?> job,
-	                                  String jenkinsUrl) {
+									  String jenkinsUrl) {
 		printDebug("_getJobDetails", null, null, Level.FINE);
 		JSONObject json = new JSONObject();
 		for (Cause cause : causes) {
@@ -1044,9 +1041,9 @@ public class DevOpsModel {
 	}
 
 	public String registerPipelineAndNotify(Run<?, ?> run, Job<?, ?> controlledJob,
-	                                        String token, String jobUrl, String jobName,
-	                                        String stageId, String jenkinsUrl,
-	                                        DevOpsPipelineChangeStepExecution stepExecution, PipelineChangeResponse changeResponse) {
+											String token, String jobUrl, String jobName,
+											String stageId, String jenkinsUrl,
+											DevOpsPipelineChangeStepExecution stepExecution, PipelineChangeResponse changeResponse) {
 		printDebug("registerPipelineAndNotify", null, null, Level.FINE);
 		String result = null;
 		try {
@@ -1134,7 +1131,7 @@ public class DevOpsModel {
 		public void setAction(PipelineChangeAction action) {
 			this.action = action;
 		}
-		
+
 		public String getMessage() {
 			return message;
 		}
@@ -1146,7 +1143,7 @@ public class DevOpsModel {
 
 	// Called from DevOpsPipelineChangeStepExecution.start()
 	public PipelineChangeResponse handlePipeline(Run<?, ?> run, Job<?, ?> controlledJob,
-	                                             DevOpsPipelineChangeStepExecution stepExecution) {
+												 DevOpsPipelineChangeStepExecution stepExecution) {
 
 		printDebug("handlePipeline", null, null, Level.FINE);
 		PipelineChangeResponse changeResponse = new PipelineChangeResponse();
@@ -1162,74 +1159,40 @@ public class DevOpsModel {
 				String stageId = getCurrentStageId(stepExecution.getContext(), graph);
 				DevOpsPipelineNode stageNode = getStageNodeById(run, stageId);
 
-				StepContext ctx = stepExecution.getContext();
-				EnvVars vars = null;
-				try {
-					vars = ctx.get(EnvVars.class);
-				} catch (Exception e) {
-					printDebug("handlePipeline", new String[]{"Exception"},
-							new String[]{e.getMessage()}, Level.SEVERE);
-				}
+				printDebug("handlePipeline",
+						new String[]{"message", "jobUrl", "jobName"},
+						new String[]{"Job is under change control", jobUrl,
+								jobName}, Level.FINE);
+				// Generate a new token
+				String token = getNewToken(controlledJob.getPronoun());
+				printDebug("handlePipeline", new String[]{"token"},
+						new String[]{token}, Level.FINE);
 
-				// If Job is under change control, register and notify SN with callback URL
-				String _result = sendIsUnderChgControl(jobUrl, jobName, stageId, stageNode,
-						GenericUtils.isMultiBranch(controlledJob), vars != null ? vars.get(
-								"BRANCH_NAME") : null);
+				// Register the Job callback hook, then notify SN
+				String _result = registerPipelineAndNotify(run, controlledJob, token,
+						jobUrl, jobName, stageNode.getId(), jenkinsUrl,
+						stepExecution, changeResponse);
 				if (_result != null) {
-					// Job is under change control
 					if (_result.equalsIgnoreCase(
-							DevOpsConstants.COMMON_RESPONSE_VALUE_TRUE.toString())) {
+							DevOpsConstants.COMMON_RESPONSE_VALUE_TRUE
+									.toString())) {
 						printDebug("handlePipeline",
-								new String[]{"message", "jobUrl", "jobName"},
-								new String[]{"Job is under change control", jobUrl,
-										jobName}, Level.FINE);
-						// Generate a new token
-						String token = getNewToken(controlledJob.getPronoun());
-						printDebug("handlePipeline", new String[]{"token"},
-								new String[]{token}, Level.FINE);
-
-						// Register the Job callback hook, then notify SN
-						_result = registerPipelineAndNotify(run, controlledJob, token,
-								jobUrl, jobName, stageNode.getId(), jenkinsUrl,
-								stepExecution, changeResponse);
-						if (_result != null) {
-							if (_result.equalsIgnoreCase(
-									DevOpsConstants.COMMON_RESPONSE_VALUE_TRUE
-											.toString())) {
-								printDebug("handlePipeline",
-										new String[]{"message", "token"},
-										new String[]{"Job registered", token}, Level.FINE);
-								//result[1] = true; // shouldWait=true
-								changeResponse.setAction(PipelineChangeAction.WAIT);
-							} else {
-								printDebug("handlePipeline", new String[]{"message"},
-										new String[]{
-												"Something went wrong when registering the job"}, Level.WARNING);
-								//result[0] = true; // shouldAbort=true
-								changeResponse.setAction(PipelineChangeAction.ABORT);
-								changeResponse.setErrorMessage(_result);
-							}
-						} else {
-							printDebug("handlePipeline", new String[]{"message"},
-									new String[]{
-											"Something went wrong when calling SN to register the job"}, Level.WARNING);
-							//result[0] = true; // shouldAbort=true
-							changeResponse.setAction(PipelineChangeAction.ABORT);
-						}
-					} else if (_result.equalsIgnoreCase(
-							DevOpsConstants.COMMON_RESPONSE_VALUE_FALSE.toString())) {
+								new String[]{"message", "token"},
+								new String[]{"Job registered", token}, Level.FINE);
+						//result[1] = true; // shouldWait=true
+						changeResponse.setAction(PipelineChangeAction.WAIT);
+					} else {
 						printDebug("handlePipeline", new String[]{"message"},
-								new String[]{"Job is not under change control"}, Level.FINE);
-					} else if (_result.equalsIgnoreCase(
-							DevOpsConstants.COMMON_RESPONSE_VALUE_UNKNOWN.toString())) {
-						printDebug("handlePipeline", new String[]{"message"},
-								new String[]{"Could not find a step for job"}, Level.WARNING);
+								new String[]{
+										"Something went wrong when registering the job"}, Level.WARNING);
 						//result[0] = true; // shouldAbort=true
 						changeResponse.setAction(PipelineChangeAction.ABORT);
+						changeResponse.setErrorMessage(_result);
 					}
 				} else {
-					printDebug("handlePipeline", new String[]{"message"}, new String[]{
-							"Something went wrong when checking if job is under change control"}, Level.WARNING);
+					printDebug("handlePipeline", new String[]{"message"},
+							new String[]{
+									"Something went wrong when calling SN to register the job"}, Level.WARNING);
 					//result[0] = true; // shouldAbort=true
 					changeResponse.setAction(PipelineChangeAction.ABORT);
 				}
@@ -1277,7 +1240,7 @@ public class DevOpsModel {
 
 	// Called from DevOpsQueueTaskDispatcher.canRun()
 	public CauseOfBlockage handleFreestyle(Queue.Item item,
-	                                       Job<?, ?> job) {
+										   Job<?, ?> job) {
 		printDebug("handleFreestyle", null, null, Level.FINE);
 		if (item != null && job != null) {
 
@@ -1415,8 +1378,8 @@ public class DevOpsModel {
 
 	// Called from DevOpsPipelineMapStepExecution.run()
 	public boolean handleStepMapping(Run<?, ?> run,
-	                                 Job<?, ?> controlledJob,
-	                                 DevOpsPipelineMapStepExecution devOpsPipelineMapStepExecution, EnvVars vars) {
+									 Job<?, ?> controlledJob,
+									 DevOpsPipelineMapStepExecution devOpsPipelineMapStepExecution, EnvVars vars) {
 
 		boolean result = false;
 		if (devOpsPipelineMapStepExecution == null)
@@ -1530,7 +1493,6 @@ public class DevOpsModel {
 		if (null != currentNode)
 			currentNode.setChangeCtrlInProgress(true);
 	}
-
 	public String handleArtifactRegistration(StepContext stepContext, Run<?, ?> run, TaskListener listener, String artifactPayload, EnvVars vars) {
 
 		String result = null;
@@ -1566,7 +1528,7 @@ public class DevOpsModel {
 	}
 
 	public String registerArtifact(TaskListener listener, String artifactsPayload, String jobName, String jobUrl,
-	                               String buildNumber, String stageName, String branchName, boolean isFreeStyle) {
+								   String buildNumber, String stageName, String branchName, boolean isFreeStyle) {
 
 		printDebug("registerArtifact", null, null, Level.FINE);
 		JSONObject queryParams = new JSONObject();
@@ -1673,7 +1635,7 @@ public class DevOpsModel {
 	}
 
 	public String createArtifactPackage(TaskListener listener, String artifactName, String artifactsPayload, String jobName, String jobUrl,
-	                                    String buildNumber, String stageName, String branchName, boolean isFreeStyle) {
+										String buildNumber, String stageName, String branchName, boolean isFreeStyle) {
 
 		printDebug("createArtifactPackage", null, null, Level.FINE);
 		JSONObject queryParams = new JSONObject();
@@ -1799,8 +1761,8 @@ public class DevOpsModel {
 	}
 
 	public JSONObject uploadData(String applicationName, String changesetNumber, String dataFormat, String path,
-				 boolean autoCommit, boolean autoValidate, String fileContent, String target, String deployableName, 
-				 		String collectionName, String transactionSource) {
+								 boolean autoCommit, boolean autoValidate, String fileContent, String target, String deployableName,
+								 String collectionName, String transactionSource) {
 		JSONObject queryParams = new JSONObject();
 
 		queryParams.put(DevOpsConstants.CONFIG_APPLICATION_NAME.toString(), applicationName);
@@ -1914,37 +1876,37 @@ public class DevOpsModel {
 				devopsConfig.getPwd(), null, null);
 		return response;
 	}
-  
+
 	public JSONObject getSnapshotsByDeployables(String applicationName, String deployableName, String changesetNumber, boolean isValidated, String transactionSource) {
 		JSONObject queryParams = new JSONObject();
-    DevOpsConfiguration devopsConfig = GenericUtils.getDevOpsConfiguration();
-    String query = "deployable_id.name=" + deployableName + "^cdm_application_id.sys_id=" + applicationName;
+		DevOpsConfiguration devopsConfig = GenericUtils.getDevOpsConfiguration();
+		String query = "deployable_id.name=" + deployableName + "^cdm_application_id.sys_id=" + applicationName;
 		String queryLimit = "";
 
-        if (StringUtils.isEmpty(changesetNumber)) {
-            if(!isValidated) {
-                query = query +"^ORDERBYDESCsys_created_on";
-                queryLimit = "1";
-            }
-            else {
-                query = query +"^validationINpassed,in_progress,passed_with_exception,requested^ORDERBYDESCsys_created_on";
-                queryLimit = "2";
-            }
-        }
-        else {
-            query = query + "^changeset_id.number=" + changesetNumber;
-            queryLimit = "1";
-		    }
-  		   
-        queryParams.put(DevOpsConstants.TABLE_API_QUERY.toString(), query);
-        queryParams.put(DevOpsConstants.TABLE_API_FIELDS.toString(), "sys_id,name,description,validation,published,sys_created_on");
-        queryParams.put(DevOpsConstants.TABLE_API_LIMIT.toString(), queryLimit);
+		if (StringUtils.isEmpty(changesetNumber)) {
+			if(!isValidated) {
+				query = query +"^ORDERBYDESCsys_created_on";
+				queryLimit = "1";
+			}
+			else {
+				query = query +"^validationINpassed,in_progress,passed_with_exception,requested^ORDERBYDESCsys_created_on";
+				queryLimit = "2";
+			}
+		}
+		else {
+			query = query + "^changeset_id.number=" + changesetNumber;
+			queryLimit = "1";
+		}
 
-        JSONObject response = CommUtils.call(DevOpsConstants.REST_GET_METHOD.toString(),
-                devopsConfig.getSnapshotStatusURL(), queryParams, null, devopsConfig.getUser(),
-                devopsConfig.getPwd(), null, transactionSource);
+		queryParams.put(DevOpsConstants.TABLE_API_QUERY.toString(), query);
+		queryParams.put(DevOpsConstants.TABLE_API_FIELDS.toString(), "sys_id,name,description,validation,published,sys_created_on");
+		queryParams.put(DevOpsConstants.TABLE_API_LIMIT.toString(), queryLimit);
 
-        return response;
+		JSONObject response = CommUtils.call(DevOpsConstants.REST_GET_METHOD.toString(),
+				devopsConfig.getSnapshotStatusURL(), queryParams, null, devopsConfig.getUser(),
+				devopsConfig.getPwd(), null, transactionSource);
+
+		return response;
 	}
 
 	public JSONObject snapShotExists(String applicationName, List<String> deployableNames, String changesetNumber) {
@@ -1999,7 +1961,7 @@ public class DevOpsModel {
 			query = query + "^name=" + snapshotName;
 
 		String fields=DevOpsConstants.CONFIG_SNAPSHOT_SYS_ID.toString()+","+DevOpsConstants.CONFIG_ENVIRONMENT_TYPE.toString();
-		
+
 		queryParams.put(DevOpsConstants.TABLE_API_QUERY.toString(), query);
 		queryParams.put(DevOpsConstants.TABLE_API_FIELDS.toString(), fields);
 		queryParams.put(DevOpsConstants.TABLE_API_LIMIT.toString(), "1");
@@ -2145,13 +2107,13 @@ public class DevOpsModel {
 
 		DevOpsConfiguration devopsConfig = GenericUtils.getDevOpsConfiguration();
 
-		String query = "node.name="+applicationName; 
+		String query = "node.name="+applicationName;
 
 		queryParams.put(DevOpsConstants.TABLE_API_QUERY.toString(), query);
 		queryParams.put(DevOpsConstants.TABLE_API_FIELDS.toString(), "sys_id,node.name");
 
 		JSONObject response = CommUtils.call(DevOpsConstants.REST_GET_METHOD.toString(),
-				devopsConfig.getValidAppURL(), queryParams, filePayloadJSON.toString(), devopsConfig.getUser(), 
+				devopsConfig.getValidAppURL(), queryParams, filePayloadJSON.toString(), devopsConfig.getUser(),
 				devopsConfig.getPwd(), null, null);
 
 		return response;
@@ -2160,7 +2122,7 @@ public class DevOpsModel {
 	public JSONObject getValidationResults(String snapshotSysId, String policy, String format) {
 
 		JSONObject queryParams = new JSONObject();
-	
+
 		DevOpsConfiguration devopsConfig = GenericUtils.getDevOpsConfiguration();
 		String baseQuery = "snapshot.sys_id="+snapshotSysId+"^is_latest=true";
 		String query = "";
@@ -2182,9 +2144,9 @@ public class DevOpsModel {
 			}
 		}
 		JSONObject response = CommUtils.call(DevOpsConstants.REST_GET_METHOD.toString(),
-				devopsConfig.getPolicyValidationURL(), queryParams, null, devopsConfig.getUser(), 
+				devopsConfig.getPolicyValidationURL(), queryParams, null, devopsConfig.getUser(),
 				devopsConfig.getPwd(), null, null);
-	
+
 		return response;
 	}
 

--- a/src/main/java/io/jenkins/plugins/model/DevOpsPipelineNode.java
+++ b/src/main/java/io/jenkins/plugins/model/DevOpsPipelineNode.java
@@ -31,8 +31,15 @@ public class DevOpsPipelineNode {
 	private boolean changeCtrlInProgress;
 	private String stageExecutionStatus;
 	private long startTime;
+	private long changeStartTime;
 	private WorkspaceAction wsAction;
 
+	public long getChangeStartTime() {
+		return changeStartTime;
+	}
+	public void setChangeStartTime(long changeStartTime) {
+		this.changeStartTime = changeStartTime;
+	}
 	public long getStartTime() {
 		return startTime;
 	}

--- a/src/main/java/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep.java
@@ -26,14 +26,57 @@ public class DevOpsPipelineChangeStep extends Step implements Serializable {
 	private String changeRequestDetails;
 	private String applicationName;
 	private String snapshotName;
-	
+	private int pollingInterval;
+	private int changeCreationTimeOut;
+	private boolean abortOnChangeCreationFailure;
+	private int changeStepTimeOut;
+	private boolean abortOnChangeStepTimeOut;
 	@DataBoundConstructor
-    public DevOpsPipelineChangeStep() {
+	public DevOpsPipelineChangeStep() {
 		enabled = true;
 		ignoreErrors = false;
 		changeRequestDetails = null;
-    }
-
+		abortOnChangeCreationFailure = true;
+		abortOnChangeStepTimeOut = true;
+	}
+	public int getPollingInterval() {
+		return pollingInterval;
+	}
+	@DataBoundSetter
+	public void setPollingInterval(Object pollingInterval) {
+		if(pollingInterval != null)
+			this.pollingInterval = pollingInterval.toString().matches("\\d+(\\.\\d+)?") ? (int)Float.parseFloat(pollingInterval.toString()) : 0;
+	}
+	public int getChangeCreationTimeOut() {
+		return changeCreationTimeOut;
+	}
+	@DataBoundSetter
+	public void setChangeCreationTimeOut(Object changeCreationTimeOut) {
+		if(changeCreationTimeOut != null)
+			this.changeCreationTimeOut = changeCreationTimeOut.toString().matches("\\d+(\\.\\d+)?") ? (int)Float.parseFloat(changeCreationTimeOut.toString()) : 0;
+	}
+	public boolean isAbortOnChangeCreationFailure() {
+		return abortOnChangeCreationFailure;
+	}
+	@DataBoundSetter
+	public void setAbortOnChangeCreationFailure(boolean abortOnChangeCreationFailure) {
+		this.abortOnChangeCreationFailure = abortOnChangeCreationFailure;
+	}
+	public int getChangeStepTimeOut() {
+		return changeStepTimeOut;
+	}
+	@DataBoundSetter
+	public void setChangeStepTimeOut(Object changeStepTimeOut) {
+		if(changeStepTimeOut != null)
+			this.changeStepTimeOut = changeStepTimeOut.toString().matches("\\d+(\\.\\d+)?") ? (int)Float.parseFloat(changeStepTimeOut.toString()) : 0;
+	}
+	public boolean isAbortOnChangeStepTimeOut() {
+		return abortOnChangeStepTimeOut;
+	}
+	@DataBoundSetter
+	public void setAbortOnChangeStepTimeOut(boolean abortOnChangeStepTimeOut) {
+		this.abortOnChangeStepTimeOut = abortOnChangeStepTimeOut;
+	}
 	public boolean isEnabled() {
 		return enabled;
 	}

--- a/src/main/java/io/jenkins/plugins/utils/DevOpsConstants.java
+++ b/src/main/java/io/jenkins/plugins/utils/DevOpsConstants.java
@@ -98,9 +98,12 @@ public enum DevOpsConstants {
 	CONFIG_UPLOAD_ID,
 	CONFIG_BUILD_NUMBER,
 	CONFIG_APP_NAME,
-
-
-
+	CHANGE_FOUND,
+	CHANGE_ASSIGNMENT_GROUP,
+	CHANGE_APPROVERS,
+	CHANGE_STATE_DISPLAY_VALUE,
+	CHANGE_START_DATE,
+	CHANGE_END_DATE,
 	COMMON_RESPONSE_CHANGE_CTRL,
 	COMMON_RESPONSE_VALUE_UNKNOWN,
 	COMMON_RESPONSE_VALUE_TRUE,
@@ -216,6 +219,7 @@ public enum DevOpsConstants {
 	SERVICENOW_PIPELINE_INFO_FILE_NAME,
 	JOBS_PATH,
 	JOBNAME_ATTR,
+	STAGENAME_ATTR,
 	PATH_SEPARATOR,
 	MULTIBRANCH_PATH_SEPARATOR,
 	PIPELINE_INFO_UPDATE_IDENTIFIER,
@@ -281,6 +285,13 @@ public enum DevOpsConstants {
 			case CONFIG_VALIDATE_STEP_DISPLAY_NAME: return "ServiceNow DevOps - DevOps Configuration Validate";
 			case CHANGE_REQUEST_UPDATE_INFO_FUNCTION_NAME: return "snDevOpsUpdateChangeInfo";
 			case CHANGE_REQUEST_UPDATE_INFO_DISPLAY_NAME: return "ServiceNow DevOps - Update Change Request Info";
+
+			case CHANGE_FOUND: return "changeFound";
+			case CHANGE_ASSIGNMENT_GROUP: return "changeAssignmentGroup";
+			case CHANGE_APPROVERS: return "changeApprovers";
+			case CHANGE_STATE_DISPLAY_VALUE: return "stateDisplayValue";
+			case CHANGE_START_DATE: return "plannedStartDate";
+			case CHANGE_END_DATE: return "plannedEndDate";
 
 			case CONFIG_SNAPSHOT_SYS_ID: return "sys_id";
 			case CONFIG_ENVIRONMENT_TYPE: return "cdm_deployable_id.environment_type";
@@ -442,6 +453,7 @@ public enum DevOpsConstants {
 			case JOBS_PATH: return "/jobs/";
 			case MULTIBRANCH_PATH_SEPARATOR: return "/branches/";
 			case JOBNAME_ATTR: return "jobName";
+			case STAGENAME_ATTR: return "stageName";
 			case SERVICENOW_PIPELINE_INFO_FILE_NAME: return "snPipelineInfo.json";
 			case PIPELINE_INFO_UPDATE_IDENTIFIER: return "snupdate";
 			case PIPELINE_INFO_DELETE_IDENTIFIER: return "sndelete";

--- a/src/main/java/io/jenkins/plugins/utils/GenericUtils.java
+++ b/src/main/java/io/jenkins/plugins/utils/GenericUtils.java
@@ -288,5 +288,20 @@ public final class GenericUtils {
 	public static boolean isNotEmpty(final CharSequence cs) {
 		return !isEmpty(cs);
 	}
+	public static String getPropertyValueFromJsonTree (Object jsonInput, String[] str) {
+		if (jsonInput == null) return null;
+		JSONObject json = JSONObject.fromObject(jsonInput);
+		Object jsonObj = null;
+		for(String key : str){
+			if(key != null && json!= null && json.containsKey(key)){
+				jsonObj = json.get(key);
+			} else return null;
 
+			if(jsonObj != null && jsonObj instanceof JSONObject)
+				json = JSONObject.fromObject(jsonObj);
+			else json = null;
+		}
+		if(jsonObj == null) return null;
+		return jsonObj.toString();
+	}
 }

--- a/src/main/resources/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep/config.jelly
@@ -11,5 +11,20 @@
 			<f:entry title="Ignore Errors" field="ignoreErrors">
                 <f:checkbox placeholder="Ignore Errors"  default="false"/>
             </f:entry>
+            <f:entry title="Polling Interval" field="pollingInterval">
+                <f:number placeholder="Polling Interval"  default="60"/>
+            </f:entry>
+            <f:entry title="Change Creation Timeout" field="changeCreationTimeOut">
+                <f:number placeholder="Change Creation Timeout"  default="3600"/>
+            </f:entry>
+            <f:entry title="Abort on change creation failure" field="abortOnChangeCreationFailure">
+                <f:checkbox placeholder="Abort on change creation failure"  default="true"/>
+            </f:entry>
+            <f:entry title="Change Step Timeout" field="changeStepTimeOut">
+                <f:number placeholder="Change Step Timeout"  default="18000"/>
+            </f:entry>
+            <f:entry title="Abort on change step timeout" field="abortOnChangeStepTimeOut">
+                <f:checkbox placeholder="Abort on change step timeout"  default="true"/>
+            </f:entry>
 	</f:section>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep/help-abortOnChangeCreationFailure.html
+++ b/src/main/resources/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep/help-abortOnChangeCreationFailure.html
@@ -1,0 +1,5 @@
+<div>
+    Abort or Resume pipeline if the change is not created till the change creation timeout. </br>
+    Checked: Abort (default, when change creation timeout specified). </br>
+    Unchecked: Resume
+</div>

--- a/src/main/resources/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep/help-abortOnChangeStepTimeOut.html
+++ b/src/main/resources/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep/help-abortOnChangeStepTimeOut.html
@@ -1,0 +1,5 @@
+<div>
+    Abort or Resume pipeline if the change step is still in progress on change step timeout. </br>
+    Checked: Abort (default, when change creation timeout specified) </br>
+    Unchecked: Resume
+</div>

--- a/src/main/resources/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep/help-changeCreationTimeOut.html
+++ b/src/main/resources/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep/help-changeCreationTimeOut.html
@@ -1,0 +1,6 @@
+<div>
+    <p>
+        Timeout value in seconds. Upon timeout, Jenkins checks the Change creation status in ServiceNow and if it failed to create the CHG, it resumes or aborts the pipeline based on the flag abortOnChangeCreationFailure.
+        By default it aborts, when timeout is specified.
+    </p>
+</div>

--- a/src/main/resources/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep/help-changeStepTimeOut.html
+++ b/src/main/resources/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep/help-changeStepTimeOut.html
@@ -1,0 +1,6 @@
+<div>
+    <p>
+        Timeout value in seconds. Upon timeout, if the Change step is still in progress, it resumes or aborts the pipeline based on the flag abortOnChangeStepTimeout.
+        By default it aborts, when timeout is specified.
+    </p>
+</div>

--- a/src/main/resources/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep/help-pollingInterval.html
+++ b/src/main/resources/io/jenkins/plugins/pipeline/steps/DevOpsPipelineChangeStep/help-pollingInterval.html
@@ -1,0 +1,3 @@
+<div>
+    Frequency at which Jenkins polls ServiceNow for the Change status and update the console logs only on Change state transitions, Asssignment Group updates, Approval updates, Planned Start/End date updates. Specify time in seconds.
+</div>


### PR DESCRIPTION
### Enhancement

- Logging change status while pipeline is pending decision to resume execution
    - Change information such as, Change Number, State, Assignment Group, Approvers, Planned Start/End date is displayed in the console logs of Jenkins and GitHub Actions, while the pipeline/workflow is pending for change approval. The ServiceNow DevOps application is polled at regular intervals and if there is any difference in the change information, it is logged directly in the console logs, thereby minimizing the hops to ServiceNow instance.